### PR TITLE
Making connect-cloudant work with express-sessions@1.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Connect-Cloudant
+# Connect-CloudantDb
 =======
 
 
 # NodeJS Session Store for Cloudant backed applications.
 
-`npm install connect-cloudant`
+`npm install connect-cloudantdb`
 
-This is based on `connect-couchbase`, found at https://github.com/christophermina/connect-couchbase.
+This is based on `connect-couchbase`, found at https://github.com/christophermina/connect-couchbase. This project is a fork of connect-cloudant with bugs fixed. The maintainer of the original connect-cloudant project could not be reached in order to accept the pull-requests.
 
 You can use like below, when setting up your Express 4.x app:
 -----
@@ -41,4 +41,4 @@ app.use(session({
 }));
 
 ```
-Please file any bugs at https://github.com/komalda/connect-cloudant/issues
+Please file any bugs at https://github.com/stanix/connect-cloudant/issues

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can use like below, when setting up your Express 4.x app:
 
 ```
 var session = require('express-session');
-var CloudantStore = require('connect-cloudant')(session);
+var CloudantStore = require('connect-cloudantdb')(session);
 var cloudantStore = new CloudantStore({
      url: cloudant database url [ https://@UserName:@Password@UserName.cloudant.com ] //required
      databaseName: 'sessions' (default sessions)  //optional

--- a/lib/connect-cloudant.js
+++ b/lib/connect-cloudant.js
@@ -184,10 +184,10 @@ module.exports = function (session) {
         promisifyGet(sid).then(function (fetchSessionData) {
             debug("GET data %s", util.inspect(fetchSessionData));
 
-            if (fetchSessionData.expires && now >= fetchSessionData.expires) {
+            if (fetchSessionData.cookie.expires && now >= fetchSessionData.cookie.expires) {
                 return fn && fn(null, null);
             } else {
-                return fn && fn(null, fetchSessionData.sess);
+                return fn(null, fetchSessionData);
             }
 
         }, function (fetchSessionError) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-cloudantdb",
   "description": "Clodant session store for Connect forked from connect-cloudant",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Ixonos Plc.",
   "main": "./index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "connect-cloudant",
-  "description": "Clodant session store for Connect",
-  "version": "1.0.6",
+  "name": "connect-cloudantdb",
+  "description": "Clodant session store for Connect forked from connect-cloudant",
+  "version": "0.0.1",
   "author": "Ixonos Plc.",
   "main": "./index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:komalda/connect-cloudant.git"
+    "url": "git@github.com:stanix/connect-cloudant.git"
   },
   "dependencies": {
     "cloudant": "^1.4.1",
@@ -16,13 +16,13 @@
     "util": "^0.10.3"
   },
   "devDependencies": {
-    "express-session": "^1.13.0"
+    "express-session": "^1.14.1"
   },
   "engines": {
     "node": "*"
   },
   "bugs": {
-    "url": "https://github.com/komalda/connect-cloudant/issues"
+    "url": "https://github.com/stanix/connect-cloudant/issues"
   },
   "scripts": {
     "test": "node cloudant-test.js"


### PR DESCRIPTION
Signed-off-by: Stanislav Radomskiy stanislav.radomskiy@ixonos.com

fetchSessionData.sess is returned in callback. Such property does not exist and callback should be called directly with fetchSessionData object, returned from the Cloudant store. After fixing this, express-session started finding the existing session based on the information in the cookie.

Same issue is when checking cookie expiration date: fetchSessionData.cookie.expires should be used instead of fetchSessionData.expires
