### PR TITLE
Returning the error object when disconnected.

### DIFF
--- a/lib/connect-cloudant.js
+++ b/lib/connect-cloudant.js
@@ -97,7 +97,7 @@ module.exports = function (session) {
         Cloudant(options.url, function (err, cloudant) {
             if (err) {
                 debug("ERROR: Could not connect to cloudant with database: " + options.databaseName);
-                self.emit('disconnect');
+                self.emit('disconnect', err);
             } else {
                 self.cloudantDB = cloudant.db.use(options.databaseName);
                 self.cloudantDB.connectionTimeout = connectOptions.connectionTimeout || 10000;


### PR DESCRIPTION
Recently I ran into an issue connecting to Cloudant and it was not immediately obvious what my issue was. Returning the error with the disconnect will help users quickly determine any potential issues they are encountering while connecting to Cloudant.